### PR TITLE
disable backface culling on doors

### DIFF
--- a/shared_doors/init.lua
+++ b/shared_doors/init.lua
@@ -103,7 +103,7 @@ local function register_shared_door(name, def)
 	end
 
 	doors.register("shared_doors:door_shared_"..name, {
-			tiles = {{name = "doors_door_"..name..".png^shared_door_lock.png", backface_culling = true}},
+			tiles = {{name = "doors_door_"..name..".png^shared_door_lock.png"}},
 			description = "Shared "..name:gsub("^%l", string.upper).." Door",
 			inventory_image = "doors_item_"..name..".png^shared_lock.png",
 			protected = def.protected,


### PR DESCRIPTION
so that glass doors appear correct.

how they appear w/ backface culling:

![image](https://user-images.githubusercontent.com/25628292/199842729-61239c06-e42a-4b48-bc04-fcd03f71d591.png)
